### PR TITLE
Enable modal dismissal on outside click

### DIFF
--- a/index.html
+++ b/index.html
@@ -5564,6 +5564,42 @@
             });
         }
 
+        const flowModalElement = document.getElementById('flowModal');
+        if (flowModalElement) {
+            flowModalElement.addEventListener('click', (event) => {
+                if (event.target === flowModalElement) {
+                    closeModal();
+                }
+            });
+        }
+
+        const podFlowModalElement = document.getElementById('podFlowModal');
+        if (podFlowModalElement) {
+            podFlowModalElement.addEventListener('click', (event) => {
+                if (event.target === podFlowModalElement) {
+                    closePodModal();
+                }
+            });
+        }
+
+        const profileModalElement = document.getElementById('profileModal');
+        if (profileModalElement) {
+            profileModalElement.addEventListener('click', (event) => {
+                if (event.target === profileModalElement) {
+                    closeProfile();
+                }
+            });
+        }
+
+        const taskDetailModalElement = document.getElementById('taskDetailModal');
+        if (taskDetailModalElement) {
+            document.addEventListener('click', (event) => {
+                if (!taskDetailModalElement.classList.contains('active')) return;
+                if (taskDetailModalElement.contains(event.target)) return;
+                closeTaskDetail();
+            });
+        }
+
         document.addEventListener('keydown', (e) => {
             if ((e.key === 'Enter' && (e.ctrlKey || e.metaKey))) {
                 if (document.getElementById('flowModal').classList.contains('active')) {


### PR DESCRIPTION
## Summary
- close the flow and pod flow builders when the overlay is clicked
- dismiss the profile modal when clicking outside its content
- close the task detail sidebar when clicking elsewhere on the page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cce7a840088332886cb3f3f114f3c1