### PR TITLE
Add pod member selector for role assignments

### DIFF
--- a/index.html
+++ b/index.html
@@ -2214,6 +2214,84 @@
             padding: 20px;
         }
 
+        .person-selector-dialog {
+            max-width: 480px;
+        }
+
+        .person-selector {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            max-height: 260px;
+            overflow-y: auto;
+        }
+
+        .person-option {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 8px;
+            padding: 12px 16px;
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--text);
+            border-radius: 8px;
+            width: 100%;
+            text-align: left;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .person-option:hover {
+            border-color: var(--green);
+            background: rgba(0, 255, 136, 0.05);
+        }
+
+        .person-option.selected {
+            border-color: var(--green);
+            background: rgba(0, 255, 136, 0.1);
+            box-shadow: 0 0 0 1px var(--green);
+        }
+
+        .person-option-header {
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+            font-size: 0.9rem;
+        }
+
+        .person-option-name {
+            font-weight: 600;
+        }
+
+        .person-option-count {
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: var(--text-dim);
+        }
+
+        .person-option-roles {
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+        }
+
+        .person-role-pill {
+            background: rgba(0, 255, 136, 0.1);
+            color: var(--green);
+            padding: 3px 8px;
+            border-radius: 999px;
+            font-size: 0.7rem;
+            letter-spacing: 0.5px;
+        }
+
+        .person-option-role-empty {
+            font-size: 0.75rem;
+            color: var(--text-dim);
+            font-style: italic;
+        }
+
         .prompt-input {
             width: 100%;
             padding: 14px 16px;
@@ -2290,6 +2368,13 @@
         .prompt-confirm:hover {
             background: var(--green);
             color: var(--bg);
+        }
+
+        .prompt-confirm:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+            background: rgba(0, 255, 136, 0.02);
+            color: var(--text-dim);
         }
 
         .btn-text {
@@ -3647,6 +3732,7 @@
         let taskFilter = 'all';
         let draggedTask = null;
         let selectedTags = [];
+        let currentPersonSelection = null;
 
         // User database
         const users = {
@@ -5408,45 +5494,123 @@
             }
         }
 
-        function quickAdd(role) {
-            showCustomPrompt(`Add person to ${role} role:`, (name) => {
-                if (name) {
-                    const triad = triadsData.find(t =>
-                        t.roles.some(r => r.name === role)
-                    );
-                    if (triad) {
-                        const roleData = triad.roles.find(r => r.name === role);
-                        roleData.people.push(name);
-                        renderRoles();
+        function getCurrentPodMemberNames() {
+            const names = new Set();
+            people.forEach(person => names.add(person.name));
+            triadsData.forEach(triad => {
+                triad.roles.forEach(role => {
+                    role.people.forEach(personName => names.add(personName));
+                });
+            });
+            return Array.from(names).sort((a, b) => a.localeCompare(b));
+        }
+
+        function getRolesForPersonInPod(personName) {
+            const roles = new Set();
+            const personRecord = people.find(person => person.name === personName);
+            if (personRecord && Array.isArray(personRecord.roles)) {
+                personRecord.roles.forEach(role => roles.add(role));
+            }
+            triadsData.forEach(triad => {
+                triad.roles.forEach(role => {
+                    if (role.people.includes(personName)) {
+                        roles.add(role.name);
                     }
+                });
+            });
+            return Array.from(roles);
+        }
+
+        function quickAdd(role) {
+            const triad = triadsData.find(t =>
+                t.roles.some(r => r.name === role)
+            );
+            if (!triad) return;
+
+            const roleData = triad.roles.find(r => r.name === role);
+            if (!roleData) return;
+
+            const assignedPeople = new Set(roleData.people);
+            const availableMembers = getCurrentPodMemberNames()
+                .filter(name => !assignedPeople.has(name))
+                .map(name => {
+                    const roles = getRolesForPersonInPod(name);
+                    return {
+                        name,
+                        otherRoles: roles.filter(existingRole => existingRole !== role)
+                    };
+                });
+
+            if (availableMembers.length === 0) {
+                alert('No available members in this pod to assign to this role.');
+                return;
+            }
+
+            showCustomPrompt({
+                message: `Add person to ${role}`,
+                peopleOptions: availableMembers,
+                callback: (name) => {
+                    if (!name) return;
+                    if (!roleData.people.includes(name)) {
+                        roleData.people.push(name);
+                    }
+                    const personRecord = people.find(person => person.name === name);
+                    if (personRecord) {
+                        if (!personRecord.roles.includes(role)) {
+                            personRecord.roles.push(role);
+                        }
+                    } else {
+                        people.push({ name, roles: [role] });
+                    }
+                    renderRoles();
+                    renderPeople();
                 }
             });
         }
 
-        function showCustomPrompt(message, callback) {
+        function showCustomPrompt({ message, peopleOptions, callback }) {
             const modal = document.createElement('div');
             modal.className = 'custom-prompt-modal';
+
+            const optionsHtml = peopleOptions.map(person => {
+                const otherRoles = person.otherRoles || [];
+                const countLabel = otherRoles.length > 0
+                    ? `${otherRoles.length} other role${otherRoles.length > 1 ? 's' : ''}`
+                    : 'Open capacity';
+                const rolesHtml = otherRoles.length > 0
+                    ? otherRoles.map(r => `<span class="person-role-pill">${r}</span>`).join('')
+                    : `<span class="person-option-role-empty">No other roles yet</span>`;
+                return `
+                    <button type="button" class="person-option" data-person="${person.name}">
+                        <div class="person-option-header">
+                            <span class="person-option-name">${person.name}</span>
+                            <span class="person-option-count">${countLabel}</span>
+                        </div>
+                        <div class="person-option-roles">
+                            ${rolesHtml}
+                        </div>
+                    </button>
+                `;
+            }).join('');
+
             modal.innerHTML = `
                 <div class="custom-prompt-overlay"></div>
-                <div class="custom-prompt-dialog">
+                <div class="custom-prompt-dialog person-selector-dialog" tabindex="-1">
                     <div class="prompt-header">
                         <div class="prompt-title">ROLE ASSIGNMENT</div>
                         <div class="prompt-message">${message}</div>
                     </div>
                     <div class="prompt-body">
-                        <input type="text"
-                               class="prompt-input"
-                               id="promptInput"
-                               placeholder="Enter codename..."
-                               autocomplete="off">
-                        <div class="prompt-suggestions"></div>
+                        <div class="person-selector">
+                            ${optionsHtml}
+                        </div>
                     </div>
                     <div class="prompt-actions">
                         <button class="prompt-btn prompt-cancel" onclick="closeCustomPrompt()">
                             <span class="btn-text">ABORT</span>
                             <span class="btn-shortcut">ESC</span>
                         </button>
-                        <button class="prompt-btn prompt-confirm" onclick="confirmCustomPrompt()">
+                        <button class="prompt-btn prompt-confirm" onclick="confirmCustomPrompt()" disabled>
                             <span class="btn-text">ASSIGN</span>
                             <span class="btn-shortcut">⏎</span>
                         </button>
@@ -5456,36 +5620,65 @@
 
             document.body.appendChild(modal);
             window.currentPromptCallback = callback;
+            currentPersonSelection = null;
 
             const overlay = modal.querySelector('.custom-prompt-overlay');
             if (overlay) {
                 overlay.addEventListener('click', closeCustomPrompt);
             }
 
-            setTimeout(() => {
-                const input = document.getElementById('promptInput');
-                if (!input) return;
-                input.focus();
-                input.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter') {
-                        confirmCustomPrompt();
-                    } else if (e.key === 'Escape') {
-                        closeCustomPrompt();
+            const confirmButton = modal.querySelector('.prompt-confirm');
+            const options = modal.querySelectorAll('.person-option');
+            options.forEach(option => {
+                option.addEventListener('click', () => {
+                    options.forEach(opt => opt.classList.remove('selected'));
+                    option.classList.add('selected');
+                    currentPersonSelection = option.dataset.person;
+                    if (confirmButton) {
+                        confirmButton.disabled = false;
                     }
                 });
-            }, 100);
+            });
 
             setTimeout(() => {
                 modal.classList.add('active');
+                const dialog = modal.querySelector('.person-selector-dialog');
+                if (dialog) {
+                    dialog.focus();
+                }
             }, 10);
+
+            modal.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') {
+                    closeCustomPrompt();
+                } else if (event.key === 'Enter') {
+                    confirmCustomPrompt();
+                }
+            });
         }
 
         function confirmCustomPrompt() {
+            const modal = document.querySelector('.custom-prompt-modal');
+            if (!modal) return;
+
+            const confirmButton = modal.querySelector('.prompt-confirm');
+            if (confirmButton && confirmButton.disabled) {
+                return;
+            }
+
+            let value = '';
             const input = document.getElementById('promptInput');
-            const value = input ? input.value : '';
+            if (input) {
+                value = input.value;
+            } else if (currentPersonSelection) {
+                value = currentPersonSelection;
+            }
+            if (!value) return;
+
+            const callback = window.currentPromptCallback;
             closeCustomPrompt();
-            if (window.currentPromptCallback) {
-                window.currentPromptCallback(value);
+            if (callback) {
+                callback(value);
             }
         }
 
@@ -5497,6 +5690,7 @@
                     modal.remove();
                 }, 300);
             }
+            currentPersonSelection = null;
             window.currentPromptCallback = null;
         }
 


### PR DESCRIPTION
## Summary
- replace the free-form role assignment prompt with a pod member selector
- highlight each person's other roles in the selector and update role data when assigning
- add styling refinements including disabled confirm states for the modal

## Testing
- Not run (static HTML project)


------
https://chatgpt.com/codex/tasks/task_b_68cce903ffa48332ad38837c9ef3a4ba